### PR TITLE
Update hugo files for v0.145 compatibility.

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -19,8 +19,9 @@ languageCode = "en-us"
 copyright = "Content distributed under CC BY-SA 4.0"
 timeout = "30s"
 
-[author]
-name = "TrueNAS"
+[params.authors]
+  "TrueNAS" = {}
+
 [outputs]
 section = ["HTML","RSS","print"]
 [outputFormats.PRINT]

--- a/themes/hugo-geekdoc/layouts/partials/microformats/opengraph.html
+++ b/themes/hugo-geekdoc/layouts/partials/microformats/opengraph.html
@@ -63,6 +63,6 @@
 {{- end }}
 
 {{- /* Facebook Page Admin ID for Domain Insights */}}
-{{- with .Site.Social.facebook_admin }}
+{{- with .Site.Params.Social.facebook_admin }}
   <meta property="fb:admins" content="{{ . }}" />
 {{- end }}

--- a/themes/hugo-geekdoc/layouts/partials/microformats/twitter_cards.html
+++ b/themes/hugo-geekdoc/layouts/partials/microformats/twitter_cards.html
@@ -10,6 +10,6 @@
 {{- with partial "utils/description" . }}
   <meta name="twitter:description" content="{{ . | plainify | htmlUnescape | chomp }}" />
 {{- end }}
-{{- with .Site.Social.twitter -}}
+{{- with .Site.Params.Social.twitter -}}
   <meta name="twitter:site" content="@{{ . }}" />
 {{- end }}


### PR DESCRIPTION
Needed to adjust a couple parameters to allow full site builds again in the newer version of Hugo Extended.