### PR TITLE
Catalog dropdown improvement and more depthful hugo logging for missing details

### DIFF
--- a/layouts/shortcodes/catalog.html
+++ b/layouts/shortcodes/catalog.html
@@ -11,8 +11,8 @@
   <select id="catalog-train-filter" class="filter-apps">
     <option value="">Trains: All</option>
     <option value="community">Community</option>
-    <option value="stable">Stable</option>
     <option value="enterprise">Enterprise</option>
+    <option value="stable">Stable</option>
   </select>
   <select id="catalog-filter" class="filter-apps">
     <option value="">Categories: All</option>
@@ -132,24 +132,33 @@
       const dropdown = document.getElementById("catalog-filter");
     
       if (Array.isArray(categories)) {
-        // Use a Set to ensure unique categories
-        const uniqueCategories = new Set(categories.map((category) => category.toLowerCase()));
-    
-        // Clear existing options to avoid duplicates
-        dropdown.innerHTML = '<option value="">Categories: All</option>';
-    
-        // Populate the dropdown with unique categories
-        uniqueCategories.forEach((category) => {
-          const option = document.createElement("option");
-          option.value = category;
-          option.textContent = category.charAt(0).toUpperCase() + category.slice(1); // Capitalize first letter
-          dropdown.appendChild(option);
+        // Deduplicate and sort categories alphabetically
+		const uniqueCategories = Array.from(new Set(categories.map((category) => category.toLowerCase())));
+		uniqueCategories.sort((a, b) => a.localeCompare(b));
+
+		function toTitleCase(str) {
+		  return str
+			.replace(/[-_]/g, ' ')
+			.split(' ')
+			.map(word => {
+			  if (word.toLowerCase() === 'ai') return 'AI';
+			  return word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
+			})
+			.join(' ');
+		}
+
+		dropdown.innerHTML = '<option value="">Categories: All</option>';
+
+		uniqueCategories.forEach((category) => {
+		  const option = document.createElement("option");
+		  option.value = category;
+		  option.textContent = toTitleCase(category);
+		  dropdown.appendChild(option);
         });
       } else {
         console.error("Categories is not an array:", categories);
       }
 
-      // Add event listeners for filtering
       const searchInput = document.getElementById("catalog-search");
       const filterDropdown = document.getElementById("catalog-filter");
       const trainDropdown = document.getElementById("catalog-train-filter");
@@ -172,7 +181,6 @@
         console.error("Train dropdown not found in the DOM.");
       }
 
-      // Apply the current filters on page load or restore
       filterCatalog();
     } catch (error) {
       console.error("Error initializing catalog filters:", error);

--- a/layouts/shortcodes/github-content.html
+++ b/layouts/shortcodes/github-content.html
@@ -48,11 +48,6 @@
     {{ if eq $appIcon "/images/default-icon.png" }}
       {{ warnf "Missing or default 'icon' in app_metadata for file: %s" $localFilePath }}
     {{ end }}
-    {{ if not (isset $versionData.app_metadata "annotations") }}
-      {{ warnf "Missing 'annotations' in app_metadata for file: %s" $localFilePath }}
-    {{ else if not $minScaleVersion }}
-      {{ warnf "Missing 'min_scale_version' in app_metadata.annotations for file: %s" $localFilePath }}
-    {{ end }}
     {{ if not $added }}
       {{ warnf "Missing 'date_added' in app_metadata for file: %s" $localFilePath }}
     {{ end }}
@@ -82,8 +77,6 @@
             <small>
               {{ if $minScaleVersion }}
                 Requires TrueNAS: <b>{{ $minScaleVersion }}</b> or newer<br>
-              {{ else }}
-                {{ warnf "No min_scale_version for %s in %s" $name $localFilePath }}
               {{ end }}
               App Version: <b>{{ $versionData.app_metadata.app_version | default "Unknown" }}</b>
               {{ if not (isset $versionData.app_metadata "app_version") }}
@@ -131,24 +124,18 @@
           </p>
           <!-- Context Section -->
           {{ if $versionData.app_metadata.run_as_context }}
-            <b>Run as Context</b>
-            <ul style="list-style-type:none;padding-left:0;">
-              {{ range $run_as_context := $versionData.app_metadata.run_as_context }}
-                <li>
-                  <small>
-                    {{ if $run_as_context.description }}
-                      {{ $run_as_context.description }}<br>
-                    {{ else }}
-                      {{ warnf "Missing run_as_context.description for %s in %s" $name $localFilePath }}
-                    {{ end }}
-                    <b>Group:</b> {{ $run_as_context.gid | default "N/A" }} / {{ $run_as_context.group_name | default "N/A" }}<br>
-                    <b>User:</b> {{ $run_as_context.uid | default "N/A" }} / {{ $run_as_context.user_name | default "N/A" }}
-                  </small>
-                </li>
-              {{ end }}
-            </ul>
-          {{ else }}
-            {{ warnf "No run_as_context for %s in %s" $name $localFilePath }}
+          <b>Run as Context</b>
+          <ul style="list-style-type:none;padding-left:0;">
+            {{ range $run_as_context := $versionData.app_metadata.run_as_context }}
+            <li>
+              <small>
+                {{ $run_as_context.description }}<br>
+                <b>Group:</b> {{ $run_as_context.gid }} / {{ $run_as_context.group_name }}<br>
+                <b>User:</b> {{ $run_as_context.uid }} / {{ $run_as_context.user_name }}
+              </small>
+            </li>
+            {{ end }}
+          </ul>
           {{ end }}
         </div>
       </div>
@@ -182,54 +169,36 @@
     <!-- Host Mounts Section -->
     {{ if $versionData.app_metadata.host_mounts }}
       {{ if gt (len $versionData.app_metadata.host_mounts) 0 }}
-        <br>
-        <details>
-          <summary>Host Mounts</summary>
-          <ul>
-            {{ range $host_mount := $versionData.app_metadata.host_mounts }}
-              <li>
-                {{ $host_mount.host_path | default "N/A" }} : {{ $host_mount.description | default "No description" }}
-                {{ if not $host_mount.host_path }}
-                  {{ warnf "Missing host_mount.host_path for %s in %s" $name $localFilePath }}
-                {{ end }}
-                {{ if not $host_mount.description }}
-                  {{ warnf "Missing host_mount.description for %s in %s" $name $localFilePath }}
-                {{ end }}
-              </li>
-            {{ end }}
-          </ul>
-        </details>
-      {{ else }}
-        {{ warnf "host_mounts is empty for %s in %s" $name $localFilePath }}
-      {{ end }}
-    {{ else }}
-      {{ warnf "No host_mounts for %s in %s" $name $localFilePath }}
-    {{ end }}
+      <br>
+      <details>
+        <summary>Host Mounts</summary>
+        <ul>
+          {{ range $host_mount := $versionData.app_metadata.host_mounts }}
+          <li>
+            {{ $host_mount.host_path }} : {{ $host_mount.description }}
+          </li>
+          {{ end }}
+        </ul>
+      </details>
+	  {{ end }}
+	{{ end }}
 
     <!-- Security Capabilities Section -->
     {{ if $versionData.app_metadata.capabilities }}
       {{ if gt (len $versionData.app_metadata.capabilities) 0 }}
-        <br>
-        <details>
-          <summary>Security Capabilities</summary>
-          <ul>
-            {{ range $capability := $versionData.app_metadata.capabilities }}
-              <li>
-                {{ $capability.description | default "No description" }}
-                {{ if not $capability.description }}
-                  {{ warnf "Missing capability.description for %s in %s" $name $localFilePath }}
-                {{ end }}
-              </li>
-            {{ end }}
-          </ul>
-        </details>
-      {{ else }}
-        {{ warnf "capabilities is empty for %s in %s" $name $localFilePath }}
-      {{ end }}
-    {{ else }}
-      {{ warnf "No capabilities for %s in %s" $name $localFilePath }}
-    {{ end }}
-
+      <br>
+      <details>
+        <summary>Security Capabilities</summary>
+        <ul>
+          {{ range $capability := $versionData.app_metadata.capabilities }}
+          <li>
+            {{ $capability.description }}
+          </li>
+          {{ end }}
+        </ul>
+      </details>
+	  {{ end }}
+	{{ end }}
     <!-- App_Versions File Expand -->
     <br>
     <details>
@@ -238,9 +207,6 @@
     </details>
     <br>
     <hr>
-  {{ else }}
-    <p>Error: Invalid JSON data in <code>{{ $localFilePath }}</code>.</p>
-    {{ warnf "Invalid JSON data in %s" $localFilePath }}
   {{ end }}
 {{ else }}
   <p>Error: File not found at <code>{{ $localFilePath }}</code>.</p>

--- a/layouts/shortcodes/github-content.html
+++ b/layouts/shortcodes/github-content.html
@@ -29,8 +29,42 @@
     {{ $minScaleVersion := $versionData.app_metadata.annotations.min_scale_version | default "" }}
     {{ $changelog := $versionData.app_metadata.changelog_url | default "" }}
     {{ $added := $versionData.app_metadata.date_added | default "" }}
-	{{ $keywords := $versionData.app_metadata.keywords | default (slice) }}
+    {{ $keywords := $versionData.app_metadata.keywords | default (slice) }}
     {{ .Page.Scratch.Set "keywords" $keywords }}
+
+    <!-- Logging for missing fields -->
+    {{ if not $name }}
+      {{ warnf "Missing 'name' in app_metadata for file: %s" $localFilePath }}
+    {{ end }}
+    {{ if not $train }}
+      {{ warnf "Missing 'train' in app_metadata for file: %s" $localFilePath }}
+    {{ end }}
+    {{ if eq $appTitle "App Title" }}
+      {{ warnf "Missing 'title' in app_metadata for file: %s" $localFilePath }}
+    {{ end }}
+    {{ if eq $appDescription "No description available." }}
+      {{ warnf "Missing 'description' in app_metadata for file: %s" $localFilePath }}
+    {{ end }}
+    {{ if eq $appIcon "/images/default-icon.png" }}
+      {{ warnf "Missing or default 'icon' in app_metadata for file: %s" $localFilePath }}
+    {{ end }}
+    {{ if not (isset $versionData.app_metadata "annotations") }}
+      {{ warnf "Missing 'annotations' in app_metadata for file: %s" $localFilePath }}
+    {{ else if not $minScaleVersion }}
+      {{ warnf "Missing 'min_scale_version' in app_metadata.annotations for file: %s" $localFilePath }}
+    {{ end }}
+    {{ if not $added }}
+      {{ warnf "Missing 'date_added' in app_metadata for file: %s" $localFilePath }}
+    {{ end }}
+    {{ if not (isset $versionData.app_metadata "keywords") }}
+      {{ warnf "Missing 'keywords' in app_metadata for file: %s" $localFilePath }}
+    {{ end }}
+    {{ if not (isset $versionData.app_metadata "changelog_url") }}
+      {{ warnf "Missing 'changelog_url' in app_metadata for file: %s" $localFilePath }}
+    {{ end }}
+    {{ if not (isset $versionData.app_metadata "home") }}
+      {{ warnf "Missing 'home' in app_metadata for file: %s" $localFilePath }}
+    {{ end }}
 
     <!-- Render the content -->
     <div class="apps-docs-sections">
@@ -48,17 +82,31 @@
             <small>
               {{ if $minScaleVersion }}
                 Requires TrueNAS: <b>{{ $minScaleVersion }}</b> or newer<br>
+              {{ else }}
+                {{ warnf "No min_scale_version for %s in %s" $name $localFilePath }}
               {{ end }}
               App Version: <b>{{ $versionData.app_metadata.app_version | default "Unknown" }}</b>
+              {{ if not (isset $versionData.app_metadata "app_version") }}
+                {{ warnf "Missing 'app_version' in app_metadata for file: %s" $localFilePath }}
+              {{ end }}
               {{ if $changelog }}
                 (<a href="{{ $changelog }}" target="_blank">Changelog</a>)
+              {{ else }}
+                {{ warnf "No changelog_url for %s in %s" $name $localFilePath }}
               {{ end }}
               <br>
               {{ with $versionData.app_metadata.keywords }}
                 Keywords: {{ delimit . ", " }}<br>
+              {{ else }}
+                {{ warnf "No keywords for %s in %s" $name $localFilePath }}
               {{ end }}
               Train: {{ title $train | default "Unknown" }}<br>
-              Home Page: <a href="{{ $versionData.app_metadata.home | default "#" }}" target="_blank">{{ $versionData.app_metadata.home | default "N/A" }}</a><br>
+              {{ if $versionData.app_metadata.home }}
+                Home Page: <a href="{{ $versionData.app_metadata.home }}" target="_blank">{{ $versionData.app_metadata.home }}</a><br>
+              {{ else }}
+                Home Page: <span style="color: #888;">N/A</span><br>
+                {{ warnf "No home page for %s in %s" $name $localFilePath }}
+              {{ end }}
             </small>
           </div>
         </div>
@@ -70,27 +118,37 @@
           <b>{{ $appTitle }} Details</b><br>
           {{ if $added }}
             Added: {{ $added }}<br>
+          {{ else }}
+            {{ warnf "No date_added for %s in %s" $name $localFilePath }}
           {{ end }}
           {{ if $versionData.last_update }}
             Last Updated: {{ (time $versionData.last_update).Format "2006-01-02" }}<br>
+          {{ else }}
+            {{ warnf "No last_update for %s in %s" $name $localFilePath }}
           {{ end }}
           <p class="app-descr">
             {{ $appDescription }}
           </p>
           <!-- Context Section -->
           {{ if $versionData.app_metadata.run_as_context }}
-          <b>Run as Context</b>
-          <ul style="list-style-type:none;padding-left:0;">
-            {{ range $run_as_context := $versionData.app_metadata.run_as_context }}
-            <li>
-              <small>
-                {{ $run_as_context.description }}<br>
-                <b>Group:</b> {{ $run_as_context.gid }} / {{ $run_as_context.group_name }}<br>
-                <b>User:</b> {{ $run_as_context.uid }} / {{ $run_as_context.user_name }}
-              </small>
-            </li>
-            {{ end }}
-          </ul>
+            <b>Run as Context</b>
+            <ul style="list-style-type:none;padding-left:0;">
+              {{ range $run_as_context := $versionData.app_metadata.run_as_context }}
+                <li>
+                  <small>
+                    {{ if $run_as_context.description }}
+                      {{ $run_as_context.description }}<br>
+                    {{ else }}
+                      {{ warnf "Missing run_as_context.description for %s in %s" $name $localFilePath }}
+                    {{ end }}
+                    <b>Group:</b> {{ $run_as_context.gid | default "N/A" }} / {{ $run_as_context.group_name | default "N/A" }}<br>
+                    <b>User:</b> {{ $run_as_context.uid | default "N/A" }} / {{ $run_as_context.user_name | default "N/A" }}
+                  </small>
+                </li>
+              {{ end }}
+            </ul>
+          {{ else }}
+            {{ warnf "No run_as_context for %s in %s" $name $localFilePath }}
           {{ end }}
         </div>
       </div>
@@ -98,15 +156,17 @@
 
     <!-- Screenshots Section -->
     {{ if $versionData.app_metadata.screenshots }}
-    <br>
-    <div class="screenshots-section">
-      <b>Screenshots</b>
-      <div class="screenshots-thumbnails" style="display: flex; flex-wrap: wrap; gap: 1rem;">
-        {{ range $index, $screenshot := $versionData.app_metadata.screenshots }}
-        <img class="screenshot-thumbnail" style="flex: 1 1 calc(33.333% - 1rem); max-width: calc(33.333% - 1rem);" src="{{ $screenshot }}" alt="Screenshot {{ add $index 1 }}" onclick="openLightbox('{{ $screenshot }}')">
-        {{ end }}
+      <br>
+      <div class="screenshots-section">
+        <b>Screenshots</b>
+        <div class="screenshots-thumbnails" style="display: flex; flex-wrap: wrap; gap: 1rem;">
+          {{ range $index, $screenshot := $versionData.app_metadata.screenshots }}
+            <img class="screenshot-thumbnail" style="flex: 1 1 calc(33.333% - 1rem); max-width: calc(33.333% - 1rem);" src="{{ $screenshot }}" alt="Screenshot {{ add $index 1 }}" onclick="openLightbox('{{ $screenshot }}')">
+          {{ end }}
+        </div>
       </div>
-    </div>
+    {{ else }}
+      {{ warnf "No screenshots found for %s in %s" $name $localFilePath }}
     {{ end }}
 
     <!-- Lightbox Modal -->
@@ -122,35 +182,52 @@
     <!-- Host Mounts Section -->
     {{ if $versionData.app_metadata.host_mounts }}
       {{ if gt (len $versionData.app_metadata.host_mounts) 0 }}
-      <br>
-      <details>
-        <summary>Host Mounts</summary>
-        <ul>
-          {{ range $host_mount := $versionData.app_metadata.host_mounts }}
-          <li>
-            {{ $host_mount.host_path }} : {{ $host_mount.description }}
-          </li>
-          {{ end }}
-        </ul>
-      </details>
+        <br>
+        <details>
+          <summary>Host Mounts</summary>
+          <ul>
+            {{ range $host_mount := $versionData.app_metadata.host_mounts }}
+              <li>
+                {{ $host_mount.host_path | default "N/A" }} : {{ $host_mount.description | default "No description" }}
+                {{ if not $host_mount.host_path }}
+                  {{ warnf "Missing host_mount.host_path for %s in %s" $name $localFilePath }}
+                {{ end }}
+                {{ if not $host_mount.description }}
+                  {{ warnf "Missing host_mount.description for %s in %s" $name $localFilePath }}
+                {{ end }}
+              </li>
+            {{ end }}
+          </ul>
+        </details>
+      {{ else }}
+        {{ warnf "host_mounts is empty for %s in %s" $name $localFilePath }}
       {{ end }}
+    {{ else }}
+      {{ warnf "No host_mounts for %s in %s" $name $localFilePath }}
     {{ end }}
 
     <!-- Security Capabilities Section -->
     {{ if $versionData.app_metadata.capabilities }}
       {{ if gt (len $versionData.app_metadata.capabilities) 0 }}
-      <br>
-      <details>
-        <summary>Security Capabilities</summary>
-        <ul>
-          {{ range $capability := $versionData.app_metadata.capabilities }}
-          <li>
-            {{ $capability.description }}
-          </li>
-          {{ end }}
-        </ul>
-      </details>
+        <br>
+        <details>
+          <summary>Security Capabilities</summary>
+          <ul>
+            {{ range $capability := $versionData.app_metadata.capabilities }}
+              <li>
+                {{ $capability.description | default "No description" }}
+                {{ if not $capability.description }}
+                  {{ warnf "Missing capability.description for %s in %s" $name $localFilePath }}
+                {{ end }}
+              </li>
+            {{ end }}
+          </ul>
+        </details>
+      {{ else }}
+        {{ warnf "capabilities is empty for %s in %s" $name $localFilePath }}
       {{ end }}
+    {{ else }}
+      {{ warnf "No capabilities for %s in %s" $name $localFilePath }}
     {{ end }}
 
     <!-- App_Versions File Expand -->
@@ -163,7 +240,9 @@
     <hr>
   {{ else }}
     <p>Error: Invalid JSON data in <code>{{ $localFilePath }}</code>.</p>
+    {{ warnf "Invalid JSON data in %s" $localFilePath }}
   {{ end }}
 {{ else }}
   <p>Error: File not found at <code>{{ $localFilePath }}</code>.</p>
+  {{ warnf "File not found at %s" $localFilePath }}
 {{ end }}


### PR DESCRIPTION
Catalog view:
 - train dropdown is alphabetical
 - category dropdown autosorts to alphabetize and apply title case when possible

Github-content shortcode:
 - add hugo warnf messages to log when a particular app is missing values from its app_versions.json file.
 - This is likely too much depth and needs to be tailored more specifically to just those values that we want to be consistently visible on the Apps Market.