### PR TITLE
Test update to telemetry caching for awards images

### DIFF
--- a/layouts/partials/telemetry-awards.html
+++ b/layouts/partials/telemetry-awards.html
@@ -1,4 +1,5 @@
-{{ $telemetryURL := "https://telemetry.sys.truenas.net/apps/truenas-apps-stats.json" }}
+{{ $timestamp := now.Unix | div 3600 }}
+{{ $telemetryURL := printf "https://telemetry.sys.truenas.net/apps/truenas-apps-stats.json?t=%d" $timestamp }}
 {{ $telemetryData := resources.GetRemote $telemetryURL | transform.Unmarshal | default dict }}
 {{ $appName := .appName | lower }}
 {{ $appTrain := .appTrain | lower }}

--- a/layouts/shortcodes/catalog.html
+++ b/layouts/shortcodes/catalog.html
@@ -28,7 +28,8 @@
 
 <!-- Catalog Cards -->
 <div class="docs-sections" id="catalog-cards">
-  {{- $telemetryURL := "https://telemetry.sys.truenas.net/apps/truenas-apps-stats.json" -}} <!-- Telemetry data URL -->
+  {{- $timestamp := now.Unix | div 3600 -}}
+  {{- $telemetryURL := printf "https://telemetry.sys.truenas.net/apps/truenas-apps-stats.json?t=%d" $timestamp -}} <!-- Telemetry data URL -->
   {{- $rawData := resources.GetRemote $telemetryURL -}} <!-- Fetch telemetry data -->
   {{- $telemetryData := $rawData | transform.Unmarshal | default dict -}} <!-- Parse telemetry data -->
   {{- $localBaseDir := "Apps_Temp/trains" -}} <!-- Base directory for temporary files -->

--- a/layouts/shortcodes/popular-apps.html
+++ b/layouts/shortcodes/popular-apps.html
@@ -1,5 +1,6 @@
 {{/* Define constants and variables */}}
-{{ $telemetryURL := "https://telemetry.sys.truenas.net/apps/truenas-apps-stats.json" }}
+{{ $timestamp := now.Unix | div 3600 }}
+{{ $telemetryURL := printf "https://telemetry.sys.truenas.net/apps/truenas-apps-stats.json?t=%d" $timestamp }}
 {{ $rawData := resources.GetRemote $telemetryURL }}
 {{ $telemetryData := $rawData | transform.Unmarshal | default dict }}
 {{ $localBaseDir := "Apps_Temp/trains" }}


### PR DESCRIPTION
There seems to be an issue with how frequently the live metrics are being applied to the apps cards, so I'm trying an update to get some better behavior.

Local builds are working fine but we'll need to monitor the jenkins pipeline execution and live site changes to ensure the telemetry is being properly applied to the apps cards.