### PR TITLE
PD-2167 Update Certificate Snippets

### DIFF
--- a/content/resources/deploy-elastic-search.md
+++ b/content/resources/deploy-elastic-search.md
@@ -41,7 +41,6 @@ Prepare TrueNAS before installing the app by:
 
 {{< include file="/static/includes/apps/BeforeYouBeginAddAppCertificate.md" >}}
 
-  <p style="margin-left: 33px">Adding a certificate is optional but if you want to use a certificate for this application, either create a new self-signed CA and certificate or import an existing CA and create the certificate for Elastic Search. A certificate is not required to deploy the application.</p>
 
 ## Installing the Application
 

--- a/content/resources/deploy-home-assistant.md
+++ b/content/resources/deploy-home-assistant.md
@@ -35,6 +35,8 @@ Prepare TrueNAS before installing Home Assistant by:
 
 {{< include file="/static/includes/apps/BeforeYouBeginAddNewAppUser.md" >}}
 
+{{< include file="/static/includes/apps/BeforeYouBeginAddAppCertificate.md" >}}
+
 ## Installing the Application
 
 {{< hint info >}}

--- a/content/resources/deploy-nextcloud.md
+++ b/content/resources/deploy-nextcloud.md
@@ -77,12 +77,10 @@ Finish the permission configuration in the app installation wizard as described 
 
 {{< include file="/static/includes/apps/BeforeYouBeginAddAppCertificate.md" >}}
 
-<div style="margin-left: 33px">Adding a certificate is optional but if you want to use a certificate for this application, create a new self-signed CA and then the certificate or import an existing CA and create the certificate for Nextcloud. A certificate is not required to deploy the application.
-
 * Set up a Nextcloud account.
 
  If you have an existing Nextcloud account, enter the credentials for that user in the installation wizard.
- If you do not have an existing Nextcloud account, you can create one in the **Nextcloud Configuration** section of the application install wizard.</div>
+ If you do not have an existing Nextcloud account, you can create one in the **Nextcloud Configuration** section of the application install wizard.
 
 ### Installing the Nextcloud App
 

--- a/content/resources/deploy-syncthing-enterprise.md
+++ b/content/resources/deploy-syncthing-enterprise.md
@@ -39,7 +39,7 @@ To install the Syncthing **enterprise** train app, do the following:
 
 {{< include file="/static/includes/apps/BeforeYouBeginAddNewAppUser.md" >}}
 
-{{< include file="/static/includes/apps/BeforeYouBegingAddAppCertificate.md" >}}
+{{< include file="/static/includes/apps/BeforeYouBeginAddAppCertificate.md" >}}
 
 {{< include file="/static/includes/apps/BeforeYouBegingAddNewAppUser.md" >}}
 
@@ -52,7 +52,7 @@ Follow the instructions below in <b>Creating Datasets for Apps</b> to correctly 
 You can organize the app dataset(s) under a parent dataset to separate them from datasets for other applications.
 For example, create a <i>syncthing</i> parent dataset with these datasets nested under it.
 If you organize the required dataset(s) under a parent dataset, set up the required ACL permissions for the parent dataset before using the app installation wizard to avoid receiving installation wizard errors.
-Use the <b>Enable ACL</b> option in the <b>Install Sycnting</b> wizard to configure permissions for the <b>home</b> and <b>data1</b> datasets.</div>
+Use the <b>Enable ACL</b> option in the <b>Install Sycnthing</b> wizard to configure permissions for the <b>home</b> and <b>data1</b> datasets.</div>
 
 <div style="margin-left: 33px">{{< include file="/static/includes/apps/BeforeYouBeginAddAppDatasetsProcedure.md" >}}
 </div>

--- a/static/includes/apps/AddingAppCertificate.md
+++ b/static/includes/apps/AddingAppCertificate.md
@@ -1,6 +1,8 @@
 &NewLine;
 
 {{< expand "Adding an App Certificate" "v" >}}
+For TrueNAS systems on the latest maintenace release of 25.04.*x* or earlier releases:
+
 1. Go to **Credentials > Certificates** to add a self-signed certificate authority (CA) and certificate for the application to use.
 
 2. Click **Add** on the **Certificate Authorities (CA)** widget to open the **Add Certificate Authority** screen.

--- a/static/includes/apps/BeforeYouBeginAddAppCertificate.md
+++ b/static/includes/apps/BeforeYouBeginAddAppCertificate.md
@@ -1,5 +1,8 @@
 &NewLine;
 
-* Create a self-signed certificate for the app (if required).
+* Import or create a self-signed certificate for the app.
+  Adding a certificate is optional, but if you want to use a certificate for this application, options vary based on the TrueNAS release:
+  * Systems with TrueNAS 25.10 or later can import an existing certificate for the app to use.
+  * Systems with the latest maintenance release of 25.04.x or earlier can create a new self-signed CA and then the certificate, or import an existing CA and create the certificate for the app to use. A certificate is not required to deploy the application.
   
   {{< include file="/static/includes/apps/AddAppCertificate.md" >}}

--- a/static/includes/apps/InstallWizardCertificateSettings.md
+++ b/static/includes/apps/InstallWizardCertificateSettings.md
@@ -1,7 +1,10 @@
 &NewLine;
 
-To use a certificate, best practice is to create the self-signed certificate before you begin using the app installation wizard.
-If you did not create a certificate before starting the installation wizard you can select the default **TrueNAS** certificate and edit the app to change the certificate after deploying the application.
+When using a certificate, the best practice is to import an existing certificate if your system is on release 25.10 or later.
+
+Systems with the latest maintenance TrueNAS 25.04.*x* or earlier releases can create a self-signed certificate before using the app installation wizard.
+
+If you did not create a certificate before starting the installation wizard, select the default **TrueNAS** certificate, and then edit the app to change the certificate after deploying the application.
 
 {{< include file="/static/includes/apps/AddAppCertificate.md" >}}
 


### PR DESCRIPTION
This PR updates the content in the two certificate snippets, and deletes duplicated text in the deploy-nextcloud.md, deploy-home-assistant.md, deploy-syncthing-enterprise.md, deploy-minio-enterprise, and deploy-elastic-search.md articles. The Mino cluster articles are not updated as the need different certificate instructions that are not worked out yet.