### PR TITLE
DOCS-2642: bump docs-shared to header/footer/nav chrome update

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/truenas/apps-web
 
 go 1.24.4
 
-require github.com/truenas/docs-shared v0.0.0-20260501150651-ada5d47288e4 // indirect
+require github.com/truenas/docs-shared v0.0.0-20260713160400-c3791782a908 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,3 +2,5 @@ github.com/truenas/docs-shared v0.0.0-20251107151355-955ee5450aab h1:4mIBPhSdZ8D
 github.com/truenas/docs-shared v0.0.0-20251107151355-955ee5450aab/go.mod h1:NynCkRXG0eYgZ9OuHiJBp3McKXzLbLUdKtkQeDwPhgc=
 github.com/truenas/docs-shared v0.0.0-20260501150651-ada5d47288e4 h1:bLxats6DEQO1OyGmZqeuF7Lwg4xP9c2cqWOPuqExNmg=
 github.com/truenas/docs-shared v0.0.0-20260501150651-ada5d47288e4/go.mod h1:NynCkRXG0eYgZ9OuHiJBp3McKXzLbLUdKtkQeDwPhgc=
+github.com/truenas/docs-shared v0.0.0-20260713160400-c3791782a908 h1:aH5d5AWOgcPfBL1/4mM1GFYbv6acoWMBkR8r75Bnyxk=
+github.com/truenas/docs-shared v0.0.0-20260713160400-c3791782a908/go.mod h1:NynCkRXG0eYgZ9OuHiJBp3McKXzLbLUdKtkQeDwPhgc=


### PR DESCRIPTION
Bumps the `docs-shared` module pin to main @ `c3791782` (v0.0.0-20260713160400-c3791782a908), which carries the merged DOCS-2642 header/footer/nav chrome refresh (docs-shared #13).

Only `go.mod` + `go.sum` change — apps-web has no local chrome; it all comes from the module.

Build-verified locally (snap Hugo 0.164.0): the new chrome renders through the module (Connect banner, Sign In dropdown, V-Series card, Solutions Alternatives column, Team link, Reddit footer icon).

Draft until ready to deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)