### PR TITLE
DOCS-2686: Drop -u from docs-shared update (fetch docs-shared@main)

### DIFF
--- a/jenkins/update-main
+++ b/jenkins/update-main
@@ -13,7 +13,10 @@ pipeline {
   stages {
     stage('Update Modules') {
         steps {
-            sh 'hugo mod get -u github.com/truenas/docs-shared'
+            // Fetch only docs-shared (main), no -u: fresh shared module without force-upgrading
+            // other modules. Forward-safe for the eventual Docsy migration (Docsy will be a pinned
+            // module that must not be force-upgraded in CI).
+            sh 'hugo mod get github.com/truenas/docs-shared@main'
             sh 'hugo mod tidy'
         }
     }


### PR DESCRIPTION
## Why

`jenkins/update-main` ran `hugo mod get -u github.com/truenas/docs-shared`. The `-u` force-upgrades docs-shared **and its transitive deps** to latest. Today the geekdoc theme is **local** and docs-shared is the only module, so risk is low — but `-u` can still bump transitive upstreams, and once this site moves to **Docsy-as-a-module** it becomes the same force-upgrade bomb we hit in connect-docs (docsy v0.16.0).

## Change

Drop `-u`, fetch the branch explicitly:
```
hugo mod get github.com/truenas/docs-shared@main
```
Fresh docs-shared without force-upgrading anything else. `hugo mod tidy` retained. Forward-safe for the Docsy migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)