### PR TITLE
DOCS-2707: Replace UserCentrics with CookieYes cookie banner

### DIFF
--- a/layouts/partials/head/custom.html
+++ b/layouts/partials/head/custom.html
@@ -8,8 +8,9 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 })(window,document,'script','dataLayer','GTM-5MZ8TZ5');</script>
 <!-- End Google Tag Manager -->
 
-<!-- Usercentrics Cookie Consent Management -->
-<script id="usercentrics-cmp" src="https://web.cmp.usercentrics.eu/ui/loader.js" data-ruleset-id="44bxGXioqiqorL" async></script>
+<!-- Start cookieyes banner -->
+<script id="cookieyes" type="text/javascript" src="https://cdn-cookieyes.com/client_data/c005e666a046ac87072fe64f27dbdc4e/script.js"></script>
+<!-- End cookieyes banner -->
 
 <!-- Favicon -->
 <link rel="icon" href="{{ "favicon/TN-favicon-32x32.png" | relURL }}" type="image/x-icon" title="TrueNAS favicon">


### PR DESCRIPTION
## Summary
- Replaces the UserCentrics cookie-consent script with the new CookieYes snippet in `layouts/partials/head/custom.html`.

## Test plan
- [x] Local `hugo` build confirms the CookieYes `<script>` tag renders.
- [ ] Confirm the CookieYes banner renders on apps.truenas.com after merge (CookieYes is domain-locked; it will not render locally).