### PR TITLE
Deprecation system improvements

### DIFF
--- a/layouts/partials/linkify-urls.html
+++ b/layouts/partials/linkify-urls.html
@@ -1,0 +1,10 @@
+{{- /* Auto-hyperlinks bare URLs in a plain-text string. Usage: {{ partial "linkify-urls.html" $someText }} */ -}}
+{{- $text := . -}}
+{{- $urlRegex := `(https?://[^\s<]+?)([.,;:)]*)(\s|$)` -}}
+{{- $urlReplace := `<a href="$1" target="_blank" rel="noopener noreferrer">$1</a>$2$3` -}}
+{{- if in $text "<a " -}}
+  {{- /* Text already contains a hand-written link; the regex can't parse HTML, so leave it alone to avoid mangling it. */ -}}
+  {{- $text | safeHTML -}}
+{{- else -}}
+  {{- replaceRE $urlRegex $urlReplace $text | safeHTML -}}
+{{- end -}}

--- a/layouts/shortcodes/github-content.html
+++ b/layouts/shortcodes/github-content.html
@@ -245,7 +245,7 @@
           </div>
 
           {{ if .reason }}
-            <p class="deprecation-reason"><strong>Reason:</strong> {{ .reason | safeHTML }}</p>
+            <p class="deprecation-reason"><strong>Reason:</strong> {{ partial "linkify-urls.html" .reason }}</p>
           {{ end }}
 
           {{ if eq .scope "partial" }}

--- a/static/js/catalog-deprecated-apps.js
+++ b/static/js/catalog-deprecated-apps.js
@@ -7,6 +7,26 @@
   'use strict';
 
   let deprecatedApps = {};
+  let removedApps = [];
+
+  // Load removed apps list so a removed app never also gets a deprecated badge
+  async function loadRemovedApps() {
+    try {
+      const response = await fetch('/data/app-removals.yaml');
+      const yamlText = await response.text();
+      const apps = [];
+      for (const line of yamlText.split('\n')) {
+        const appMatch = line.match(/^([a-z0-9_-]+):/);
+        if (appMatch && !line.startsWith('#') && !line.startsWith(' ')) {
+          apps.push(appMatch[1]);
+        }
+      }
+      removedApps = apps;
+    } catch (error) {
+      console.error('Failed to load removed apps:', error);
+      removedApps = [];
+    }
+  }
 
   // Calculate days until removal
   function daysUntilRemoval(removalDateStr) {
@@ -208,7 +228,9 @@
 
     // Badge text based on scope
     if (scope === 'full') {
-      badge.textContent = 'REMOVED';
+      // Full scope means the whole app is deprecated and scheduled for removal,
+      // not that it has been removed yet — that's tracked separately via app-removals.yaml.
+      badge.textContent = 'DEPRECATED';
     } else {
       // For partial, always show text that informs readers the App is changing in a significant way and action is required on their part when they have it deployed.
       badge.textContent = 'ACTION REQUIRED';
@@ -234,7 +256,7 @@
     let processedCount = 0;
     cards.forEach(card => {
       const appName = getAppName(card);
-      if (appName) {
+      if (appName && !removedApps.includes(appName)) {
         const appDeprecation = getAppDeprecation(appName);
         if (appDeprecation && appDeprecation.deprecations.length > 0) {
           const mostUrgent = getMostUrgentDeprecation(appDeprecation.deprecations);
@@ -258,8 +280,8 @@
       return;
     }
 
-    // Load deprecated apps list
-    await loadDeprecatedApps();
+    // Load deprecated apps list, and removed apps so removal always takes precedence
+    await Promise.all([loadDeprecatedApps(), loadRemovedApps()]);
 
     // Process cards initially
     processCatalogCards();


### PR DESCRIPTION
- Fixed catalog badge mislabeling: apps with a fully-scoped deprecation (scope: "full" in app-deprecations.yaml) now show a DEPRECATED badge instead of incorrectly showing REMOVED before the app has actually been removed (static/js/catalog-deprecated-apps.js)
- Added a safeguard so the REMOVED badge always takes priority — an app already tracked in app-removals.yaml will never also get a DEPRECATED/ACTION REQUIRED badge, even if it briefly lingers in the deprecations data (static/js/catalog-deprecated-apps.js)
- Auto-hyperlink bare URLs in deprecation notice "Reason" text so they render as clickable links instead of plain text, with a guard to skip any reason text that already contains a hand-written link (new partial layouts/partials/linkify-urls.html, used in layouts/shortcodes/github-content.html)