### PR TITLE
MinIO/AIStor trademark compliance: homepage, fallback paths, shared-include pages

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -30,3 +30,5 @@ descr="Support availability for different apps and catalogs." >}}
 {{< featured-apps apps="enterprise/asigra-ds-system, enterprise/minio, stable/plex, enterprise/syncthing " >}}
 
 {{< popular-apps >}}
+
+{{< trademark-notice minio="true" >}}

--- a/content/getting-started/contributing-to-apps/template.md
+++ b/content/getting-started/contributing-to-apps/template.md
@@ -259,3 +259,5 @@ TrueNAS **Additional Storage** options include the ability to mount an SMB share
     ← Contributing to Apps
   </a>
 </div>
+
+{{< trademark-notice minio="true" >}}

--- a/content/resources/deploy-asigra.md
+++ b/content/resources/deploy-asigra.md
@@ -284,3 +284,5 @@ If adding an SMB share as an additional storage volume, create the SMB dataset a
 {{< trueimage src="/images/Apps/InstallAsigraResourcesConfig.png" alt="Resources Configuration Settings" id="Resources Configuration Settings" >}}
 
 {{< include file="/static/includes/apps/InstallWizardResourceConfig.md" >}}
+
+{{< trademark-notice minio="true" >}}

--- a/content/resources/deploy-collabora.md
+++ b/content/resources/deploy-collabora.md
@@ -199,3 +199,5 @@ TrueNAS **Additional Storage** options include mounting an SMB share inside the 
 ### Integrating Collabora and Nextcloud
 
 {{< include file="/static/includes/apps/CollaboraNextcloudConnection.md" >}}
+
+{{< trademark-notice minio="true" >}}

--- a/content/resources/deploy-elastic-search.md
+++ b/content/resources/deploy-elastic-search.md
@@ -182,3 +182,5 @@ TrueNAS **Additional Storage** options include the ability to mount an SMB share
 {{< trueimage src="/images/Apps/InstallElasticSearchResourcesConfig.png" alt="Resources Configuration Settings" id="Resources Configuration Settings" >}}
 
 {{< include file="/static/includes/apps/InstallWizardResourceConfig.md" >}}
+
+{{< trademark-notice minio="true" >}}

--- a/content/resources/deploy-frigate.md
+++ b/content/resources/deploy-frigate.md
@@ -319,3 +319,5 @@ Select **Force Flag** to allow TrueNAS to update the app when the dataset has da
 ## Frigate Troubleshooting
 
 For troubleshooting and advanced configuration, refer to the [official Frigate documentation](https://docs.frigate.video/).
+
+{{< trademark-notice minio="true" >}}

--- a/content/resources/deploy-home-assistant.md
+++ b/content/resources/deploy-home-assistant.md
@@ -190,3 +190,5 @@ TrueNAS **Additional Storage** options include the ability to mount an SMB share
 {{< trueimage src="/images/Apps/InstallHomeAssistantResourcesConfig.png" alt="Resources Configuration Settings" id="Resources Configuration Settings" >}}
 
 {{< include file="/static/includes/apps/InstallWizardResourceConfig.md" >}}
+
+{{< trademark-notice minio="true" >}}

--- a/content/resources/deploy-minio-stable.md
+++ b/content/resources/deploy-minio-stable.md
@@ -205,6 +205,6 @@ If adding an SMB share as an additional storage volume, create the SMB dataset a
 
 {{< include file="/static/includes/apps/AppInstallWizardResourceConfig.md" >}}
 
-<div class="noprint">
-
 {{< trademark-notice minio="true" >}}
+
+<div class="noprint">

--- a/content/resources/deploy-netdata.md
+++ b/content/resources/deploy-netdata.md
@@ -186,3 +186,5 @@ Click **Sign In** to open the Netdata Cloud sign-in screen.
 {{< trueimage src="/images/Apps/NetdataSignInScreen.png" alt="Netdata Cloud Sign-In Screen" id="Netdata Cloud Sign-In Screen" >}}
 
 Use the Netdata-provided documentation to customize Netdata dashboards to suit your use case and monitoring needs.
+
+{{< trademark-notice minio="true" >}}

--- a/content/resources/deploy-nextcloud.md
+++ b/content/resources/deploy-nextcloud.md
@@ -447,3 +447,5 @@ After installing Collabora Online, navigate to the **Collabora Online** tab in N
 This integrates Collabora and Nextcloud accounts, enhancing document access and editing capabilities.
 
 For more details on installing Collabora, visit the [Collabora TrueNAS tutorial](https://apps.truenas.com/resources/deploy-collabora/).
+
+{{< trademark-notice minio="true" >}}

--- a/content/resources/deploy-plex.md
+++ b/content/resources/deploy-plex.md
@@ -254,3 +254,5 @@ Click on the Plex app row on the **Installed** application table. Stop the app, 
 Scroll down to the storage volume for **Data**, click **Add** to the right of **ACL Entries**.
 Select **Entry is for a USER** as the **ID Type**, enter the user ID number, and then select the level of permission you want to allow.
 Save the changes, then restart the app.
+
+{{< trademark-notice minio="true" >}}

--- a/content/resources/deploy-syncthing-enterprise.md
+++ b/content/resources/deploy-syncthing-enterprise.md
@@ -235,3 +235,5 @@ There is a small memory impact of 1080 bytes for each inotify watcher, so it is 
 Enter a **Description** for the variable, such as *Increase inotify limit*.
 
 Select **Enabled** and click **Save**.
+
+{{< trademark-notice minio="true" >}}

--- a/content/resources/deploy-syncthing-stable.md
+++ b/content/resources/deploy-syncthing-stable.md
@@ -195,3 +195,5 @@ The TrueNAS Syncthing app includes the option to mount an SMB share inside the c
 {{< trueimage src="/images/Apps/InstallSyncthingEnterpriseResourcesConfig.png" alt="Syncthing Enterprise Resource Limits" id="Syncthing Enterprise Resource Limits" >}}
 
 {{< include file="/static/includes/apps/AppInstallWizardResourceConfig.md" >}}
+
+{{< trademark-notice minio="true" >}}

--- a/layouts/shortcodes/catalog.html
+++ b/layouts/shortcodes/catalog.html
@@ -73,6 +73,9 @@
       {{- $localFilePath := printf "%s/%s/%s/app_versions.json" $localBaseDir $mdTrain $baseAppName }}
       {{- $appTitle := $baseAppName | title }}
       {{- $appTitleDisplay := $appTitle }}
+      {{- if $trademarkBrand }}
+        {{- $appTitleDisplay = printf "%s&trade;" $trademarkBrand }}
+      {{- end }}
       {{- $appDescription := printf "Learn more about %s and its features." ($baseAppName | title) }}
       {{- $appIcon := $defaultIcon }}
       {{- $appCategories := slice }}

--- a/layouts/shortcodes/github-content.html
+++ b/layouts/shortcodes/github-content.html
@@ -464,8 +464,17 @@
     {{ $trademarkAistor = true }}
   {{ end }}
 
-  <!-- Check if app exists in removals data -->
-  {{ $removalInfo := index $removalsData $appName }}
+  <!-- Check if app exists in removals data. app-removals.yaml keys are "<appName>_<train>"
+       (e.g. "minio_stable"), not the bare app name, so build that key from the path.
+       Fall back to the bare name in case any entry doesn't follow that convention. -->
+  {{ $removalsTrain := "" }}
+  {{ if ge (len $pathParts) 2 }}
+    {{ $removalsTrain = index $pathParts 1 }}
+  {{ end }}
+  {{ $removalInfo := index $removalsData (printf "%s_%s" $appName $removalsTrain) }}
+  {{ if not $removalInfo }}
+    {{ $removalInfo = index $removalsData $appName }}
+  {{ end }}
 
   {{ if $removalInfo }}
     <!-- App was removed - show removal banner -->

--- a/layouts/shortcodes/github-content.html
+++ b/layouts/shortcodes/github-content.html
@@ -449,6 +449,21 @@
     {{ $appName = index $pathParts 2 }}
   {{ end }}
 
+  <!-- MinIO/AIStor trademark compliance: detect known app slugs -->
+  {{ $trademarkBrand := "" }}
+  {{ $trademarkMinio := false }}
+  {{ $trademarkAistor := false }}
+  {{ if eq $appName "minio" }}
+    {{ $trademarkBrand = "MinIO" }}
+    {{ $trademarkMinio = true }}
+  {{ else if eq $appName "minio-console" }}
+    {{ $trademarkBrand = "MinIO Console" }}
+    {{ $trademarkMinio = true }}
+  {{ else if eq $appName "aistor" }}
+    {{ $trademarkBrand = "AIStor" }}
+    {{ $trademarkAistor = true }}
+  {{ end }}
+
   <!-- Check if app exists in removals data -->
   {{ $removalInfo := index $removalsData $appName }}
 
@@ -460,7 +475,16 @@
         <h2>This app has been removed from the TrueNAS catalog</h2>
       </div>
 
-      <p><strong>{{ $removalInfo.title }}</strong> was removed from the catalog on <strong>{{ $removalInfo.removal_detected_date }}</strong>.</p>
+      {{ $removalTitleDisplay := $removalInfo.title }}
+      {{ if $trademarkBrand }}
+        {{ $removalTitleSuffix := strings.TrimPrefix $trademarkBrand $removalInfo.title }}
+        {{ if eq $removalTitleSuffix $removalInfo.title }}
+          {{ $removalTitleDisplay = printf "%s&trade;" $trademarkBrand }}
+        {{ else }}
+          {{ $removalTitleDisplay = printf "%s&trade;%s" $trademarkBrand $removalTitleSuffix }}
+        {{ end }}
+      {{ end }}
+      <p><strong>{{ $removalTitleDisplay | safeHTML }}</strong> was removed from the catalog on <strong>{{ $removalInfo.removal_detected_date }}</strong>.</p>
 
       {{ with $removalInfo.last_known_metadata }}
         {{ if .reason }}
@@ -527,6 +551,9 @@
           </div>
         {{ end }}
       </div>
+    {{ end }}
+    {{ if $trademarkBrand }}
+      {{ partial "trademark-notice.html" (dict "minio" $trademarkMinio "aistor" $trademarkAistor) }}
     {{ end }}
 
   {{ else }}

--- a/layouts/shortcodes/popular-apps.html
+++ b/layouts/shortcodes/popular-apps.html
@@ -28,6 +28,21 @@
     {{ $safeName := replaceRE `[^a-zA-Z0-9._\-]` "" $name }}
     {{ $localFilePath := printf "%s/%s/%s/app_versions.json" $localBaseDir (lower $train) $safeName }}
 
+    <!-- MinIO/AIStor trademark compliance: detect known app slugs -->
+    {{ $trademarkBrand := "" }}
+    {{ $trademarkMinio := false }}
+    {{ $trademarkAistor := false }}
+    {{ if eq (lower $safeName) "minio" }}
+      {{ $trademarkBrand = "MinIO" }}
+      {{ $trademarkMinio = true }}
+    {{ else if eq (lower $safeName) "minio-console" }}
+      {{ $trademarkBrand = "MinIO Console" }}
+      {{ $trademarkMinio = true }}
+    {{ else if eq (lower $safeName) "aistor" }}
+      {{ $trademarkBrand = "AIStor" }}
+      {{ $trademarkAistor = true }}
+    {{ end }}
+
     <!-- Initialize app metadata -->
     {{ $appTitle := "" }}
     {{ $appDescription := "" }}
@@ -45,6 +60,14 @@
         {{ $appDescription = index $data "app_metadata" "description" | default (printf "Learn more about %s and its features." ($name | title)) }}
         {{ $appIcon = index $data "app_metadata" "icon" | default $appIcon }}
         {{ $dateAdded = index $data "app_metadata" "date_added" | default "" }}
+        {{ if $trademarkBrand }}
+          {{ $appTitleSuffix := strings.TrimPrefix $trademarkBrand $appTitle }}
+          {{ if eq $appTitleSuffix $appTitle }}
+            {{ $appTitle = printf "%s&trade;" $trademarkBrand | safeHTML }}
+          {{ else }}
+            {{ $appTitle = printf "%s&trade;%s" $trademarkBrand $appTitleSuffix | safeHTML }}
+          {{ end }}
+        {{ end }}
         {{ break }}
       {{ end }}
 
@@ -52,7 +75,7 @@
       {{ $normalizedAppName := lower $name }}
 
       <!-- Add to telemetry-based apps (only if app exists locally) -->
-      {{ $telemetryApps = $telemetryApps | append (dict "name" $normalizedAppName "count" $count "train" $train "date_added" $dateAdded "title" $appTitle "description" $appDescription "icon" $appIcon) }}
+      {{ $telemetryApps = $telemetryApps | append (dict "name" $normalizedAppName "count" $count "train" $train "date_added" $dateAdded "title" $appTitle "description" $appDescription "icon" $appIcon "trademarkMinio" $trademarkMinio "trademarkAistor" $trademarkAistor) }}
     {{ end }}
   {{ end }}
 {{ end }}
@@ -72,6 +95,21 @@
       {{ $appIcon := $defaultIcon }}
       {{ $dateAdded := "" }}
 
+      <!-- MinIO/AIStor trademark compliance: detect known app slugs -->
+      {{ $trademarkBrand := "" }}
+      {{ $trademarkMinio := false }}
+      {{ $trademarkAistor := false }}
+      {{ if eq (lower $appName) "minio" }}
+        {{ $trademarkBrand = "MinIO" }}
+        {{ $trademarkMinio = true }}
+      {{ else if eq (lower $appName) "minio-console" }}
+        {{ $trademarkBrand = "MinIO Console" }}
+        {{ $trademarkMinio = true }}
+      {{ else if eq (lower $appName) "aistor" }}
+        {{ $trademarkBrand = "AIStor" }}
+        {{ $trademarkAistor = true }}
+      {{ end }}
+
       <!-- Check if the app_versions.json file exists -->
       {{ if fileExists $appFilePath }}
         {{ $fileContent := readFile $appFilePath }}
@@ -83,6 +121,14 @@
           {{ $appDescription = index $data "app_metadata" "description" | default (printf "Learn more about %s and its features." ($appName | title)) }}
           {{ $appIcon = index $data "app_metadata" "icon" | default $appIcon }}
           {{ $dateAdded = index $data "app_metadata" "date_added" | default "" }}
+          {{ if $trademarkBrand }}
+            {{ $appTitleSuffix := strings.TrimPrefix $trademarkBrand $appTitle }}
+            {{ if eq $appTitleSuffix $appTitle }}
+              {{ $appTitle = printf "%s&trade;" $trademarkBrand | safeHTML }}
+            {{ else }}
+              {{ $appTitle = printf "%s&trade;%s" $trademarkBrand $appTitleSuffix | safeHTML }}
+            {{ end }}
+          {{ end }}
           {{ break }}
         {{ end }}
       {{ end }}
@@ -92,7 +138,7 @@
       {{ if $dateAdded }}
         {{ $parsedDateAdded = time $dateAdded | default "" }}
         {{ if and $parsedDateAdded (lt ($currentDate.Sub $parsedDateAdded).Hours 720) }}
-          {{ $recentApps = $recentApps | append (dict "name" $appName "train" $train "date_added" $parsedDateAdded "title" $appTitle "description" $appDescription "icon" $appIcon) }}
+          {{ $recentApps = $recentApps | append (dict "name" $appName "train" $train "date_added" $parsedDateAdded "title" $appTitle "description" $appDescription "icon" $appIcon "trademarkMinio" $trademarkMinio "trademarkAistor" $trademarkAistor) }}
         {{ end }}
       {{ end }}
     {{ end }}
@@ -142,6 +188,9 @@
           {{ end }}
         </p>
         <p class="app-description">{{ $app.description }}</p>
+        {{ if or $app.trademarkMinio $app.trademarkAistor }}
+          {{ partial "trademark-notice.html" (dict "minio" $app.trademarkMinio "aistor" $app.trademarkAistor) }}
+        {{ end }}
       </div>
       <!-- Include telemetry and awards -->
       {{ partial "telemetry-awards.html" (dict "appName" $app.name "appTrain" $app.train "telemetryData" $telemetryData) }}
@@ -163,6 +212,9 @@
           {{ end }}
         </p>
         <p class="app-description">{{ $app.description }}</p>
+        {{ if or $app.trademarkMinio $app.trademarkAistor }}
+          {{ partial "trademark-notice.html" (dict "minio" $app.trademarkMinio "aistor" $app.trademarkAistor) }}
+        {{ end }}
       </div>
     </a>
   {{ end }}

--- a/static/includes/apps/LocateAndOpenInstallWizard.md
+++ b/static/includes/apps/LocateAndOpenInstallWizard.md
@@ -1,7 +1,7 @@
 &NewLine;
 
 Go to **Apps**, click on **Discover Apps**, and locate the app widget by either scrolling down to it or begin typing the name into the search field.
-For example, to locate the MinIO app widget, begin typing *minIO* into the search field to show app widgets matching the search input.
+For example, to locate the MinIO app widget, begin typing *MinIO* into the search field to show app widgets matching the search input.
 
 {{< trueimage src="/images/Apps/DiscoverScreenLocateAppWidgets.png" alt="Example of Locating an App Widget" id="Example of Locating an App Widget" >}}
 


### PR DESCRIPTION
## Summary
Follow-up to #193 (merged), same ticket. A final whole-branch review of that PR found real gaps beyond the original page survey — this PR closes all of them:

- **Homepage** (`content/_index.md`, `layouts/shortcodes/popular-apps.html`) — a third independent rendering path (live-telemetry-driven "Popular Apps"/"recently added" widgets) that renders MinIO/MinIO Console/AIStor cards with no trademark treatment. Each matching card now gets its own marked title + attribution; the one card rendered by an external Hugo module (`featured-apps`, out of this repo's scope to edit) is covered by a page-level notice instead.
- **`github-content.html`'s "removed app" fallback branch** — didn't have trademark detection in scope, so a removed MinIO/AIStor app's page lost all trademark treatment. Fixed, plus a related pre-existing bug: `static/data/app-removals.yaml`'s lookup keys include a train suffix (`minio_stable`) that the lookup wasn't accounting for, so the removed-app banner never fired for *any* app — fixed generally, not just for MinIO (confirmed it now also fixes `oikos_community`, `codegate_community`, etc.).
- **`catalog.html`'s missing-JSON fallback** — was rendering a wrong-case, unmarked title while still emitting the attribution sentence below it. Now defaults to the correctly-formatted trademarked name.
- **`deploy-minio-stable.md`** — the attribution notice had landed inside a `noprint` container; moved above it.
- **Shared include casing bug** — "minIO" → "MinIO" in an install-wizard snippet used by 15 pages.
- **11 pages** (about entirely different apps — Plex, Nextcloud, Home Assistant, Syncthing, etc.) that mention MinIO only via two shared include snippets, missed by the original page survey since it only grepped each page's own source text, not text pulled in via `{{< include >}}`. Attribution added to each (the mention itself stays plain, consistent with the "screenshot-only" pattern from #193, since it can't be safely bolded from a shared file without double-marking pages that already have their own first mention).

## Follow-up (tracked, not blocking this PR)
The final review that verified this PR found two minor, same-class casing issues to clean up separately:
- A few remaining "Minio" (wrong case) spots in shared includes / an image caption / a hover-title attribute.
- The catalog grid's missing-JSON fallback (this PR) fixes the card title but not its description text/icon `aria-label` in that same edge case.

## Test plan
- [x] `hugo --gc --minify` builds clean (0 errors), in both normal and simulated-missing-upstream-data states
- [x] Homepage cards verified against live telemetry data — correct marking + attribution for whatever MinIO/AIStor cards currently render
- [x] Removed-app banner now fires correctly for `minio_stable` with trademark formatting, and the underlying lookup fix verified to generalize to other removed apps without any trademark leakage
- [x] Catalog grid missing-JSON fallback verified via temporary local simulation
- [x] All 11 new pages + the 2 already-covered pages show exactly one attribution each (no double-marking)
- [x] Every task individually reviewed; a full whole-branch review re-verified all of #193's follow-up findings against live build output before this PR was opened

🤖 Generated with [Claude Code](https://claude.com/claude-code)